### PR TITLE
Got footer to behave and remove old code not needed.

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -6,14 +6,12 @@
   margin-left: 10% !important;
 }
 
-html {
-  overflow-y: scroll;
-}
-
 body {
   position: absolute;
   z-index: 3;
   width: 100%;
+  overflow-y: scroll;
+  /* min-height: 100vh; */
 }
 
 .hide {
@@ -66,11 +64,9 @@ body {
   width: 0px;
 }
 
-/*to keep footer from overlapping with content - margin bottom*/
+/*to keep footer from overlapping with content - padding bottom*/
 #page-container {
-  position: relative;
-  min-height: 100vh;
-  margin-bottom: 50px;
+  padding-bottom: 30px;
 }
 
 /*removes negative margin of -1rem, causes overlapping with footer*/
@@ -81,23 +77,22 @@ body {
 /*fixed footer with margin*/
 .footer {
   position: fixed !important;
-  margin-top: 50px !important;
   bottom: 0 !important;
   left: 0 !important;
   width: 100% !important;
   color: white;
 }
 
-/*remove border on menu logout button so it matches list items in menu*/
-.item.logout {
-  border-width: 0px;
-  border-style: none;
-}
 
 /* to remove extra padding on mobile footer when menu stacked*/
 @media only screen and (max-width: 767px){
-.ui.stackable.divided:not(.vertically).grid>.row>.column {
-  padding-top: 0!important;
-  padding-bottom: 0!important;
-}
+  .ui.stackable.divided:not(.vertically).grid>.column:not(.row) {
+    padding-top: 10px !important;
+    padding-bottom: 10px !important;
+  }
+
+  .footer {
+    position: relative !important;
+  }
+
 }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -10,15 +10,16 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css"
         integrity="sha512-8bHTC73gkZ7rZ7vpqUQThUDhqcNFyYi2xgDgPDHc+GXVGHXq+xPjynxIopALmOPqzo9JZj0k6OqqewdGO3EsrQ=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="shortcut icon" type="image/ico" href="/assets/images/favicon.ico" />
     <script src="https://kit.fontawesome.com/3341819b7b.js" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="/assets/css/style.css">
 </head>
 
 <body>
-    <div id="page-container">
+        <div id="page-container">
     {{>header}}
+
     {{{body}}}
+    </div>
     {{>footer}}
     {{#if loggedIn}}
     <script src="/assets/js/logout.js"></script>
@@ -28,7 +29,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.js"
         integrity="sha512-dqw6X88iGgZlTsONxZK9ePmJEFrmHwpuMrsUChjAw1mRUhUITE5QU9pkcSox+ynfLhL15Sv2al5A0LVyDCmtUw=="
         crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-        </div>
+        
 </body>
 
 </html>

--- a/views/partials/footer.handlebars
+++ b/views/partials/footer.handlebars
@@ -2,7 +2,7 @@
   <div class="ui blue">
     <div class="ui container">
 
-      <div class="ui stackable inverted divided equal height stackable grid">
+      <div class="ui inverted divided equal height stackable grid">
 
         <div class="three wide column">
           <h4><a href="/contact" class="contact">Contact</a></h4>


### PR DESCRIPTION
remove duplicate stackable class in footer handlbars, remove old favicon link rel in main handlbars, move page-container div to incompass header and body on main handlbars to prevent space gap on home, add html overflow scroll to body instead of html to remove extra scroll bar, remove un needed css on pagecontainer -- change from margin to padding. remove old item logout styles not needed since button changed to link, make footer position relative on mobile so there is more room.